### PR TITLE
Add x.com video download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ docker-compose up --build -d
 | `!grupos del <id do grupo>` | Sua conversa consigo mesmo     | `!grupos del 551199999999-14700@g.us`    | Remove grupos monitorados para !resumo                              |
 | `!chatgpt <txt>`            | Qualquer conversa              | `!chatgpt Está correto?`                 | Envia `<txt>` + mensagem citada ao ChatGPT e devolve a resposta     |
 | `!img <prompt>`             | Qualquer conversa              | `!img gato astronauta, estilo cartoon`   | Gera e envia uma imagem via DALL·E 3 (Standard) diretamente no chat |
-| `!download`                 | Sua conversa consigo mesmo     | (Responder a um link)                    | Baixa vídeos do Instagram, TikTok ou YouTube Shorts e envia no chat |
+| `!download`                 | Sua conversa consigo mesmo     | (Responder a um link)                    | Baixa vídeos do Instagram, TikTok, YouTube Shorts ou X/Twitter e envia no chat |
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func mustEnv(key, fallback string) string {
 	return fallback
 }
 
-var reVideoURL = regexp.MustCompile(`https?://[^\s]*?(instagram\.com|tiktok\.com|vm\.tiktok\.com|vt\.tiktok\.com|youtube\.com|youtu\.be)[^\s]*`)
+var reVideoURL = regexp.MustCompile(`https?://[^\s]*?(instagram\.com|tiktok\.com|vm\.tiktok\.com|vt\.tiktok\.com|youtube\.com|youtu\.be|x\.com|twitter\.com)[^\s]*`)
 
 func extractVideoURL(text string) string {
 	match := reVideoURL.FindString(text)


### PR DESCRIPTION
## Summary
- expand video URL regex to include `x.com` and `twitter.com`
- update documentation for `!download` command

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686eab8c66f4832aa78b447e6d3f995a