### PR TITLE
Add detailed trigger logging for resumo command

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,24 @@ func isAuthorizedGroup(chat string) bool {
 	return allowedGroups[chat]
 }
 
+func logTriggerEvaluation(triggerName, chatBare, senderJID, body string) {
+	trimmedBody := strings.TrimSpace(body)
+	log.Printf(
+		"🔎 Trigger check %s: chat=%s authorized=%t allowedEntry=%t sender=%s isFromMe=%t userJID=%s bodyRaw=%q bodyTrimmed=%q matchesExact=%t historyCount=%d",
+		triggerName,
+		chatBare,
+		isAuthorizedGroup(chatBare),
+		allowedGroups[chatBare],
+		senderJID,
+		isFromMe(senderJID),
+		userJID,
+		body,
+		trimmedBody,
+		body == triggerName,
+		len(messageHistory[chatBare]),
+	)
+}
+
 func bareJID(full string) string {
 	parts := strings.SplitN(full, "@", 2)
 	local := strings.SplitN(parts[0], ":", 2)[0]
@@ -486,6 +504,9 @@ func handleMessage(cli *whatsmeow.Client, v *events.Message) {
 	}
 
 	// ==== comando !resumo (antes de gravar) ====
+	if strings.HasPrefix(strings.TrimSpace(body), "!resumo") {
+		logTriggerEvaluation("!resumo", chatBare, senderJID, body)
+	}
 	if isAuthorizedGroup(chatBare) && isFromMe(senderJID) && body == "!resumo" {
 		log.Println("✅ Disparou !resumo")
 		logs := messageHistory[chatBare]


### PR DESCRIPTION
## Summary
- add a helper that logs all variables involved when evaluating the !resumo trigger
- log trigger evaluations whenever a message starts with !resumo so failures can be diagnosed

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd1cb05770832ab1dac9013c86c9d6